### PR TITLE
solve build warnings for null refernces

### DIFF
--- a/src/openapi2excel/Builders/OperationWorksheetBuilder.cs
+++ b/src/openapi2excel/Builders/OperationWorksheetBuilder.cs
@@ -94,7 +94,7 @@ internal class OperationWorksheetBuilder(IXLWorkbook workbook, OpenApiDocumentat
 
    private void AdjustDescriptionColumnToContents()
    {
-      _worksheet.LastColumnUsed().AdjustToContents();
+      _worksheet.LastColumnUsed()?.AdjustToContents();
    }
 
    private void AddOperationInfos(string path, OpenApiPathItem pathItem, OperationType operationType,

--- a/src/openapi2excel/Common/OpenApiSchemaExtension.cs
+++ b/src/openapi2excel/Common/OpenApiSchemaExtension.cs
@@ -32,7 +32,7 @@ internal static class OpenApiSchemaExtension
    public static string GetPropertyDescription(this OpenApiSchema schema)
    {
       if (string.IsNullOrEmpty(schema.Description))
-         return schema.Description;
+         return string.Empty;
 
       return schema.Description.StartsWith('\'') ? "'" + schema.Description : schema.Description;
    }
@@ -100,17 +100,17 @@ internal static class OpenApiSchemaExtension
 
          return value switch
          {
-            OpenApiString val => val.Value,
-            OpenApiInteger val => val.Value.ToString(),
-            OpenApiBoolean val => val.Value.ToString(),
-            OpenApiByte val => val.Value.ToString(),
-            OpenApiDate val => val.Value.ToShortDateString(),
-            OpenApiDateTime val => val.Value.ToString(CultureInfo.CurrentCulture),
-            OpenApiDouble val => val.Value.ToString(CultureInfo.CurrentCulture),
-            OpenApiFloat val => val.Value.ToString(CultureInfo.CurrentCulture),
-            OpenApiLong val => val.Value.ToString(CultureInfo.CurrentCulture),
-            OpenApiPassword val => val.Value,
-            _ => ""
+            OpenApiString val => val.Value ?? string.Empty,
+            OpenApiInteger val => val.Value.ToString() ?? string.Empty,
+            OpenApiBoolean val => val.Value.ToString() ?? string.Empty,
+            OpenApiByte val => val.Value.ToString() ?? string.Empty,
+            OpenApiDate val => val.Value.ToShortDateString() ?? string.Empty,
+            OpenApiDateTime val => val.Value.ToString(CultureInfo.CurrentCulture) ?? string.Empty,
+            OpenApiDouble val => val.Value.ToString(CultureInfo.CurrentCulture) ?? string.Empty,
+            OpenApiFloat val => val.Value.ToString(CultureInfo.CurrentCulture) ?? string.Empty,
+            OpenApiLong val => val.Value.ToString(CultureInfo.CurrentCulture) ?? string.Empty,
+            OpenApiPassword val => val.Value ?? string.Empty,
+            _ => string.Empty
          };
       }
    }
@@ -129,17 +129,17 @@ internal static class OpenApiSchemaExtension
       }
       return schema.Example switch
       {
-         OpenApiString val => val.Value,
-         OpenApiInteger val => val.Value.ToString(),
-         OpenApiBoolean val => val.Value.ToString(),
-         OpenApiByte val => val.Value.ToString(),
-         OpenApiDate val => val.Value.ToShortDateString(),
-         OpenApiDateTime val => val.Value.ToString(CultureInfo.CurrentCulture),
-         OpenApiDouble val => val.Value.ToString(CultureInfo.CurrentCulture),
-         OpenApiFloat val => val.Value.ToString(CultureInfo.CurrentCulture),
-         OpenApiLong val => val.Value.ToString(CultureInfo.CurrentCulture),
-         OpenApiPassword val => val.Value,
-         _ => ""
+         OpenApiString val => val.Value ?? string.Empty,
+         OpenApiInteger val => val.Value.ToString() ?? string.Empty,
+         OpenApiBoolean val => val.Value.ToString() ?? string.Empty,
+         OpenApiByte val => val.Value.ToString() ?? string.Empty,
+         OpenApiDate val => val.Value.ToShortDateString() ?? string.Empty,
+         OpenApiDateTime val => val.Value.ToString(CultureInfo.CurrentCulture) ?? string.Empty,
+         OpenApiDouble val => val.Value.ToString(CultureInfo.CurrentCulture) ?? string.Empty,
+         OpenApiFloat val => val.Value.ToString(CultureInfo.CurrentCulture) ?? string.Empty,
+         OpenApiLong val => val.Value.ToString(CultureInfo.CurrentCulture) ?? string.Empty,
+         OpenApiPassword val => val.Value ?? string.Empty,
+         _ => string.Empty
       };
    }
 
@@ -157,17 +157,17 @@ internal static class OpenApiSchemaExtension
       }
       return schema.Default switch
       {
-         OpenApiString val => val.Value,
-         OpenApiInteger val => val.Value.ToString(),
-         OpenApiBoolean val => val.Value.ToString(),
-         OpenApiByte val => val.Value.ToString(),
-         OpenApiDate val => val.Value.ToShortDateString(),
-         OpenApiDateTime val => val.Value.ToString(CultureInfo.CurrentCulture),
-         OpenApiDouble val => val.Value.ToString(CultureInfo.CurrentCulture),
-         OpenApiFloat val => val.Value.ToString(CultureInfo.CurrentCulture),
-         OpenApiLong val => val.Value.ToString(CultureInfo.CurrentCulture),
-         OpenApiPassword val => val.Value,
-         _ => ""
+         OpenApiString val => val.Value ?? string.Empty,
+         OpenApiInteger val => val.Value.ToString() ?? string.Empty,
+         OpenApiBoolean val => val.Value.ToString() ?? string.Empty,
+         OpenApiByte val => val.Value.ToString() ?? string.Empty,
+         OpenApiDate val => val.Value.ToShortDateString() ?? string.Empty,
+         OpenApiDateTime val => val.Value.ToString(CultureInfo.CurrentCulture) ?? string.Empty,
+         OpenApiDouble val => val.Value.ToString(CultureInfo.CurrentCulture) ?? string.Empty,
+         OpenApiFloat val => val.Value.ToString(CultureInfo.CurrentCulture) ?? string.Empty,
+         OpenApiLong val => val.Value.ToString(CultureInfo.CurrentCulture) ?? string.Empty,
+         OpenApiPassword val => val.Value ?? string.Empty,
+         _ => string.Empty
       };
    }
 }


### PR DESCRIPTION
OperationWorksheetBuilder.cs (Line 97):

Changed _worksheet.LastColumnUsed().AdjustToContents(); to _worksheet.LastColumnUsed()?.AdjustToContents();
This uses the null conditional operator to safely handle cases where no columns are used
OpenApiSchemaExtension.cs (Multiple lines):

GetPropertyDescription method: Fixed to return string.Empty instead of schema.Description when it's null
GetEnumValue method (Line ~101): Added null coalescing operators (?? string.Empty) to all ToString() calls and string values
GetExampleDescription method (Line ~130): Same null-safe approach for all value conversions
GetDefaultDescription method (Line ~158): Same null-safe approach for all value conversions

Null conditional operator (?.): Used for the worksheet operation where a no-op is acceptable
Null coalescing operator (?? string.Empty): Used for string conversions to ensure non-null returns
Safe default returns: Changed "" to string.Empty for consistency and clarity

✅ Build succeeds with 0 warnings (previously had 8 warnings)
✅ All tests pass (1/1 test still passing)
✅ No breaking changes to existing functionality
✅ Maintainable code that properly handles nullable reference types